### PR TITLE
Add ruby and crystal

### DIFF
--- a/crystal/fast.cr
+++ b/crystal/fast.cr
@@ -1,0 +1,14 @@
+require "csv"
+require "json"
+require "file_utils"
+
+csv_path = File.join("../data/data.csv")
+json_path = File.join("../data/crystal/json")
+FileUtils.mkdir_p(json_path)
+
+File.open(csv_path) do |csv_file|
+  CSV.each_row(csv_file).with_index do |row, i|
+    json_file_path = File.join(json_path, "json#{i}.json")
+    File.write(json_file_path, row.to_json)
+  end
+end

--- a/ruby/fast.rb
+++ b/ruby/fast.rb
@@ -1,0 +1,14 @@
+require "csv"
+require "json"
+require "fileutils"
+
+csv_path = File.join(__dir__, "../data/data.csv")
+json_path = File.join(__dir__, "../data/ruby/json")
+FileUtils.mkdir_p(json_path)
+
+File.open(csv_path) do |csv_file|
+  CSV.foreach(csv_file).with_index do |row, i|
+    json_file_path = File.join(json_path, "json#{i}.json")
+    File.write(json_file_path, row.to_json)
+  end
+end


### PR DESCRIPTION
For Ruby, install ruby 3.2.0 and run with:

`ruby --yjit fast.rb`

For Crystal:

```
brew install crystal
crystal build fast.cr --release
./fast
```

You can see how similar the two languages are... and Crystal is typed! 

The only thing about this benchmark is that it generates TONS of I/O because of all the files it creates. If you were to skip writing to disk, it would showcase the speed if each language better. Right now it's all I/O bound.